### PR TITLE
Choose what polar image version to use

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "anstream"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,6 +90,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "backtrace"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
+name = "base64"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -94,6 +130,18 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+
+[[package]]
+name = "bytes"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "cc"
@@ -184,6 +232,22 @@ dependencies = [
  "proc-macro-hack",
  "tiny-keccak",
 ]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
@@ -367,6 +431,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "rand",
+ "reqwest",
  "rust-ini",
  "serde",
  "serde_json",
@@ -377,6 +442,15 @@ dependencies = [
  "slog-async",
  "slog-term",
  "uuid",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -407,10 +481,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+
+[[package]]
+name = "futures-io"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+
+[[package]]
+name = "futures-util"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
 
 [[package]]
 name = "generic-array"
@@ -431,6 +583,31 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "gimli"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+
+[[package]]
+name = "h2"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91fc23aa11be92976ef4729127f1a74adf36d8436f7816b185d18df956790833"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap 1.9.3",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -479,10 +656,91 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "http"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "0.14.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.4.9",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "indexmap"
@@ -506,6 +764,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
+
+[[package]]
 name = "is-terminal"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -521,6 +785,21 @@ name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+
+[[package]]
+name = "js-sys"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
@@ -541,6 +820,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
 
 [[package]]
+name = "memchr"
+version = "2.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi 0.3.2",
+ "libc",
+]
+
+[[package]]
 name = "num_threads"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -550,10 +889,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+
+[[package]]
+name = "openssl"
+version = "0.10.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
+dependencies = [
+ "bitflags 2.4.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "ordered-multimap"
@@ -564,6 +956,12 @@ dependencies = [
  "dlv-list",
  "hashbrown 0.13.2",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
@@ -608,6 +1006,24 @@ dependencies = [
  "pest",
  "sha2",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "ppv-lite86"
@@ -679,14 +1095,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "thiserror",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.11.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
 ]
 
 [[package]]
@@ -698,6 +1161,12 @@ dependencies = [
  "cfg-if",
  "ordered-multimap",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
@@ -725,6 +1194,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
+name = "schannel"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -750,6 +1251,18 @@ version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
 dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
  "itoa",
  "ryu",
  "serde",
@@ -799,6 +1312,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "slog"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,6 +1352,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -858,10 +1400,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "take_mut"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
+
+[[package]]
+name = "tempfile"
+version = "3.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall 0.3.5",
+ "rustix",
+ "windows-sys",
+]
 
 [[package]]
 name = "term"
@@ -944,6 +1520,92 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f38200e3ef7995e5ef13baec2f432a6da0aa9ac495b2c0e8f3b7eec2c92d653"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "libc",
+ "mio",
+ "num_cpus",
+ "pin-project-lite",
+ "socket2 0.5.4",
+ "windows-sys",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d68074620f57a0b21594d9735eb2e98ab38b17f80d3fcb189fca266771ca60d"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+
+[[package]]
+name = "tracing"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+
+[[package]]
 name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -956,16 +1618,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
+
+[[package]]
+name = "url"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
 
 [[package]]
 name = "utf8parse"
@@ -983,16 +1671,107 @@ dependencies = [
 ]
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+
+[[package]]
+name = "web-sys"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"
@@ -1081,3 +1860,13 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.1.0"
 
 [dependencies]
 anyhow = "1.0.71"
+reqwest = { version = "0.11.22",  features = ["blocking", "json"] }
 hex = "0.4.3"
 rust-ini = "0.19"
 log = "0.4.18"

--- a/docs/bitcoind_docker/Dockerfile
+++ b/docs/bitcoind_docker/Dockerfile
@@ -1,0 +1,33 @@
+FROM debian:stable-slim
+
+ARG BITCOIN_VERSION
+ENV PATH=/opt/bitcoin-${BITCOIN_VERSION}/bin:$PATH
+
+RUN apt-get update -y \
+  && apt-get install -y curl gosu \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN SYS_ARCH="$(uname -m)" \
+  && curl -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-${SYS_ARCH}-linux-gnu.tar.gz \
+  && tar -xzf *.tar.gz -C /opt \
+  && rm *.tar.gz
+
+RUN curl -SLO https://raw.githubusercontent.com/bitcoin/bitcoin/master/contrib/bitcoin-cli.bash-completion \
+  && mkdir /etc/bash_completion.d \
+  && mv bitcoin-cli.bash-completion /etc/bash_completion.d/ \
+  && curl -SLO https://raw.githubusercontent.com/scop/bash-completion/master/bash_completion \
+  && mv bash_completion /usr/share/bash-completion/
+
+COPY docker-entrypoint.sh /entrypoint.sh
+COPY bashrc /home/bitcoin/.bashrc
+
+RUN chmod a+x /entrypoint.sh
+
+VOLUME ["/home/bitcoin/.bitcoin"]
+
+EXPOSE 18443 18444 28334 28335
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+CMD ["bitcoind"]

--- a/docs/bitcoind_docker/bashrc
+++ b/docs/bitcoind_docker/bashrc
@@ -1,0 +1,8 @@
+# enable bash completion in interactive shells
+if ! shopt -oq posix; then
+  if [ -f /usr/share/bash-completion/bash_completion ]; then
+    . /usr/share/bash-completion/bash_completion
+  elif [ -f /etc/bash_completion ]; then
+    . /etc/bash_completion
+  fi
+fi

--- a/docs/bitcoind_docker/docker-entrypoint.sh
+++ b/docs/bitcoind_docker/docker-entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -e
+
+# containers on linux share file permissions with hosts.
+# assigning the same uid/gid from the host user
+# ensures that the files can be read/write from both sides
+if ! id bitcoin > /dev/null 2>&1; then
+  USERID=${USERID:-1000}
+  GROUPID=${GROUPID:-1000}
+
+  echo "adding user bitcoin ($USERID:$GROUPID)"
+  groupadd -f -g $GROUPID bitcoin
+  useradd -r -u $USERID -g $GROUPID bitcoin
+  chown -R $USERID:$GROUPID /home/bitcoin
+fi
+
+if [ $(echo "$1" | cut -c1) = "-" ]; then
+  echo "$0: assuming arguments for bitcoind"
+
+  set -- bitcoind "$@"
+fi
+
+if [ "$1" = "bitcoind" ] || [ "$1" = "bitcoin-cli" ] || [ "$1" = "bitcoin-tx" ]; then
+  echo "Running as bitcoin user: $@"
+  exec gosu bitcoin "$@"
+fi
+
+echo "$@"
+exec "$@"

--- a/doppler_files/basic_setup.doppler
+++ b/doppler_files/basic_setup.doppler
@@ -1,4 +1,3 @@
-// defined one bitcoind as a miner and find a block every 10s
 BITCOIND_MINER bd1 10s
 BITCOIND bd2
 BITCOIND bd3

--- a/doppler_files/different_images.doppler
+++ b/doppler_files/different_images.doppler
@@ -1,0 +1,22 @@
+BITCOIND IMAGE older polarlightning/bitcoind:22.0
+LND IMAGE 16 polarlightning/lnd:0.16.4-beta
+LND IMAGE 17 polarlightning/lnd:0.17.0-beta
+
+BITCOIND_MINER bd1 10s
+BITCOIND bd2 older
+BITCOIND bd3
+
+LND lnd2 16 PAIR bd1
+LND lnd1 PAIR bd1
+LND lnd3 17 PAIR bd3
+LND lnd4 PAIR bd2
+
+VISUALIZER view
+
+UP
+
+lnd1 OPEN_CHANNEL lnd2 AMT 500000
+lnd2 OPEN_CHANNEL lnd3 AMT 500000
+lnd3 OPEN_CHANNEL lnd1 AMT 500000
+lnd4 OPEN_CHANNEL lnd2 AMT 500000
+lnd3 OPEN_CHANNEL lnd4 AMT 500000

--- a/doppler_files/toycln.doppler
+++ b/doppler_files/toycln.doppler
@@ -1,5 +1,5 @@
 BITCOIND_MINER bd1 10m
-CLN cln1 PAIR bd1
+CORELN cln1 PAIR bd1
 LND lnd1 PAIR bd1
 LND lnd2 PAIR bd1
 UP

--- a/src/bin/parsetest.rs
+++ b/src/bin/parsetest.rs
@@ -5,7 +5,7 @@ use pest::Parser;
 
 fn main() {
     let contents =
-        fs::read_to_string("./doppler_files/starting_amounts.doppler").expect("file read error");
+        fs::read_to_string("./doppler_files/toycln.doppler").expect("file read error");
     print!("read file content");
     let parsed = DopplerParser::parse(Rule::page, &contents).expect("parse error");
     println!("{:#?}", parsed);

--- a/src/cln.rs
+++ b/src/cln.rs
@@ -1,6 +1,6 @@
 use crate::{
     copy_file, create_folder, get_absolute_path, run_command, L1Node, L2Node, NodeCommand,
-    NodePair, Options, NETWORK,
+    NodePair, Options, NETWORK, ImageInfo,
 };
 use anyhow::{anyhow, Error, Result};
 use conf_parser::processer::{read_to_file_conf, FileConf, Section};
@@ -15,8 +15,6 @@ use std::{
     time::Duration,
 };
 use uuid::Uuid;
-
-const CLN_IMAGE: &str = "elementsproject/lightningd:v23.05.1";
 
 #[derive(Default, Debug, Clone)]
 pub struct Cln {
@@ -127,7 +125,7 @@ impl L2Node for Cln {
     }
 }
 
-pub fn build_cln(options: &mut Options, name: &str, pair: &NodePair) -> Result<()> {
+pub fn build_cln(options: &mut Options, name: &str, image: &ImageInfo, pair: &NodePair) -> Result<()> {
     let cln_conf = build_and_save_config(options, name, pair).unwrap();
     debug!(
         options.global_logger(),
@@ -140,7 +138,7 @@ pub fn build_cln(options: &mut Options, name: &str, pair: &NodePair) -> Result<(
     let bitcoind = vec![cln_conf.bitcoind_node_container_name.clone()];
     let cln = Service {
         depends_on: DependsOnOptions::Simple(bitcoind),
-        image: Some(CLN_IMAGE.to_string()),
+        image: Some(image.get_image()),
         container_name: Some(cln_conf.container_name.clone()),
         ports: Ports::Short(vec![format!(
             "{}:{}",

--- a/src/eclair.rs
+++ b/src/eclair.rs
@@ -13,10 +13,8 @@ use std::{
 
 use crate::{
     copy_file, create_folder, get_absolute_path, restart_service, run_command, L1Node, L2Node,
-    NodeCommand, NodePair, Options, NETWORK,
+    NodeCommand, NodePair, Options, NETWORK, ImageInfo,
 };
-
-const ECLAIR_IMAGE: &str = "polarlightning/eclair:0.9.0";
 
 #[derive(Default, Debug, Clone)]
 pub struct Eclair {
@@ -121,7 +119,7 @@ impl L2Node for Eclair {
     }
 }
 
-pub fn build_eclair(options: &mut Options, name: &str, pair: &NodePair) -> Result<()> {
+pub fn build_eclair(options: &mut Options, name: &str, image: &ImageInfo, pair: &NodePair) -> Result<()> {
     let mut eclair_conf = build_and_save_config(options, name, pair).unwrap();
     debug!(
         options.global_logger(),
@@ -132,7 +130,7 @@ pub fn build_eclair(options: &mut Options, name: &str, pair: &NodePair) -> Resul
     let bitcoind = vec![eclair_conf.bitcoind_node_container_name.clone()];
     let eclair = Service {
         depends_on: DependsOnOptions::Simple(bitcoind),
-        image: Some(ECLAIR_IMAGE.to_string()),
+        image: Some(image.get_image()),
         container_name: Some(eclair_conf.container_name.clone()),
         env_file: Some(EnvFile::Simple(".env".to_owned())),
         ports: Ports::Short(vec![

--- a/src/hash_map_wrapper.rs
+++ b/src/hash_map_wrapper.rs
@@ -1,0 +1,38 @@
+use std::collections::HashMap;
+use std::hash::Hash;
+pub struct CloneableHashMap<K, V> {
+    inner_map: HashMap<K, V>,
+}
+
+impl<K, V> CloneableHashMap<K, V>
+where
+    K: PartialEq,
+    K: Eq,
+    K: Hash,
+{
+    pub fn new() -> Self {
+        CloneableHashMap {
+            inner_map: HashMap::new(),
+        }
+    }
+
+    pub fn get(&self, key: K) -> Option<&V> {
+        self.inner_map.get(&key)
+    }
+
+    pub fn insert(&mut self, key: K, value: V) -> Option<V> {
+        self.inner_map.insert(key, value)
+    }
+}
+
+impl<K, V> Clone for CloneableHashMap<K, V>
+where
+    K: Clone,
+    V: Clone,
+{
+    fn clone(&self) -> Self {
+        CloneableHashMap {
+            inner_map: self.inner_map.clone(),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,10 @@ mod node_kind;
 mod parser;
 mod visualizer;
 mod workflow;
+mod hash_map_wrapper;
+mod polar_default_images;
 
+pub use hash_map_wrapper::*;
 pub use bitcoind::*;
 pub use cln::*;
 pub use conf_handler::*;
@@ -20,5 +23,5 @@ pub use node::*;
 pub use node_kind::*;
 pub use parser::*;
 pub use visualizer::*;
-pub use visualizer::*;
 pub use workflow::*;
+pub use polar_default_images::*;

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,4 +1,4 @@
-use crate::{Bitcoind, Options};
+use crate::{Bitcoind, NodeKind, Options};
 use anyhow::Error;
 use rand::Rng;
 use serde_yaml::{from_slice, Value};
@@ -106,6 +106,57 @@ pub trait L1Node: Any {
         amt: i64,
         address: String,
     ) -> Result<(), Error>;
+}
+
+#[derive(Default, Debug, Clone, PartialEq)]
+pub struct ImageInfo {
+    tag: String,
+    name: String,
+    is_custom: bool,
+    node_kind: NodeKind
+}
+
+impl ImageInfo {
+    pub fn new(tag: String, name: String, is_custom: bool, node_kind: NodeKind) -> ImageInfo {
+        ImageInfo {
+            tag,
+            name,
+            is_custom,
+            node_kind
+        }
+    }
+    pub fn get_image(&self) -> String {
+        if self.is_custom {
+            self.tag.clone()
+        } else {
+            match self.node_kind {
+                NodeKind::Lnd => {
+                    format!("polarlightning/lnd:{}", self.tag.clone())
+                },
+                NodeKind::Bitcoind | NodeKind::BitcoindMiner => {
+                    format!("polarlightning/bitcoind:{}", self.tag.clone())
+                },
+                NodeKind::Coreln => {
+                    format!("polarlightning/clightning:{}", self.tag.clone())
+                 },
+                NodeKind::Eclair => { 
+                    format!("polarlightning/eclair:{}", self.tag.clone())
+                },
+                NodeKind::Visualizer => {
+                    self.tag.clone()
+                }
+            }
+        }
+    }
+    pub fn is_image(&self, name: &str) -> bool {
+        self.name == name
+    }
+    pub fn get_name(&self) -> String {
+        self.name.clone()
+    }
+    pub fn get_tag(&self) -> String {
+        self.tag.clone()
+    }
 }
 
 #[derive(Default, Debug, Clone)]

--- a/src/node_kind.rs
+++ b/src/node_kind.rs
@@ -4,10 +4,11 @@ use std::convert::TryFrom;
 
 use crate::Rule;
 
-#[derive(Debug)]
+#[derive(Debug,Default, Clone, PartialEq, Eq, Hash)]
 pub enum NodeKind {
     Bitcoind,
     BitcoindMiner,
+    #[default]
     Lnd,
     Coreln,
     Eclair,

--- a/src/parser/grammar.pest
+++ b/src/parser/grammar.pest
@@ -1,5 +1,5 @@
 WHITESPACE = _{ " " }
-EMPTY_LINE = _{"" ~ NEWLINE}
+EMPTY_LINE = _{"" ~ NEWLINE | (" ")* ~ NEWLINE}
 
 COMMENT = _{ "//" ~ (!NEWLINE ~ ANY)* ~ NEWLINE }
 
@@ -11,14 +11,19 @@ time_digits = { "s" | "m" | "h" }
 
 node_kind = { "BITCOIND_MINER" | "BITCOIND" | "LND" | "CORELN" | "ECLAIR" | "VISUALIZER" }
 
-node_def = { node_kind ~ ident }
+image_name = @{ ASCII_ALPHANUMERIC+ }
+image_version = @{ (ASCII_ALPHANUMERIC | PUNCTUATION)+ }
 
-node_pair = { node_kind ~ ident ~ "PAIR" ~ (ident ~ num | ident) }
+node_def = { (node_kind ~ ident ~ image_name) | (node_kind ~ ident )  }
 
-node_miner = { node_kind ~ ident ~ (num)* ~ time_digits }
+node_image = { node_kind ~ "IMAGE" ~ image_name ~ image_version }
+
+node_pair = { node_kind ~ (( ident ~ "PAIR") | ( ident ~ image_name ~ "PAIR")) ~ (ident ~ num | ident) }
+
+node_miner = { node_kind ~ ident ~ ( (image_name ~ (num)* ~ time_digits) | ((num)* ~ time_digits)) }
 
 skip_conf = { "SKIP_CONF" }
-conf = { node_pair | node_miner | node_def }
+conf = { node_pair | node_image  | node_miner | node_def  }
 every = { "EVERY" }
 loop = { "LOOP" }
 start  = { ((loop ~ num ~ every ~ num ~ time_digits ) | (loop ~ num) | (loop ~ every ~ num ~ time_digits ))  }
@@ -33,10 +38,10 @@ flag = { "--" }
 sub_command = { ( flag ~ ident | num )* }
 
 ln_node_action_type = { "OPEN_CHANNEL" | "SEND_LN" | "SEND_ON_CHAIN" | "CLOSE_CHANNEL" }
-ln_node_action = { (ident ~ ln_node_action_type ~ ident ~ "AMT" ~ (num ~ sub_command | num )) | (ident ~ ln_node_action_type ~ ( ident ~ sub_command | ident)) }
+ln_node_action = { (image_name ~ ln_node_action_type ~ image_name ~ "AMT" ~ (num ~ sub_command | num )) | (image_name ~ ln_node_action_type ~ ( image_name ~ sub_command | image_name)) }
 
 btc_node_action_type = { "MINE_BLOCKS" }
-btc_node_action = { (ident ~ btc_node_action_type ~ ( num ~ sub_command | num)) }
+btc_node_action = { (image_name ~ btc_node_action_type ~ ( num ~ sub_command | num)) }
 
-page = { SOI ~ (COMMENT |  ( ((skip_conf ~ NEWLINE) | (conf ~ NEWLINE)* ~ (up ~ NEWLINE) )  ~ ( EMPTY_LINE | (loop_content* ~ NEWLINE ) | (ln_node_action ~ NEWLINE ) | (btc_node_action ~ NEWLINE ) )*) ) ~ EOI }
+page = { SOI ~ ( EMPTY_LINE | COMMENT |  ( (EMPTY_LINE | (skip_conf ~ NEWLINE) | (EMPTY_LINE | conf ~ NEWLINE)* ~ (up ~ NEWLINE) )  ~ ( EMPTY_LINE | (loop_content* ~ NEWLINE ) | (ln_node_action ~ NEWLINE ) | (btc_node_action ~ NEWLINE ) )*) ) ~ EOI }
 

--- a/src/polar_default_images.rs
+++ b/src/polar_default_images.rs
@@ -1,0 +1,158 @@
+use anyhow::{anyhow, Error};
+use reqwest::blocking::get;
+use serde::Deserialize;
+
+use crate::{CloneableHashMap, ImageInfo, NodeKind};
+
+#[derive(Debug, Deserialize)]
+struct Image {
+    latest: String,
+    #[serde(rename = "versions")]
+    _versions: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Images {
+    #[serde(rename = "LND")]
+    lnd: Image,
+    #[serde(rename = "c-lightning")]
+    c_lightning: Image,
+    eclair: Image,
+    bitcoind: Image,
+}
+
+#[derive(Debug, Deserialize)]
+struct Payload {
+    #[serde(rename = "version")]
+    _version: i32,
+    images: Images,
+}
+
+pub fn get_latest_polar_images() -> Result<CloneableHashMap<NodeKind, ImageInfo>, Error> {
+    let url = "https://raw.githubusercontent.com/jamaljsr/polar/master/docker/nodes.json";
+
+    let response = get(url).map_err(|err| anyhow!("error getting polar images: {}", err))?;
+    if response.status().is_success() {
+        let payload: Payload = response.json::<Payload>().expect("Failed to parse JSON");
+        let mut hash_map = CloneableHashMap::new();
+        // NOTE: safe to use * as name since the grammar of the parse wont allow for special characters for the image name, only for the image tag
+        hash_map.insert(
+            NodeKind::Lnd,
+            ImageInfo::new(
+                payload.images.lnd.latest,
+                String::from("*1"),
+                false,
+                NodeKind::Lnd,
+            ),
+        );
+        hash_map.insert(
+            NodeKind::Coreln,
+            ImageInfo::new(
+                payload.images.c_lightning.latest,
+                String::from("*2"),
+                false,
+                NodeKind::Coreln,
+            ),
+        );
+        hash_map.insert(
+            NodeKind::Eclair,
+            ImageInfo::new(
+                payload.images.eclair.latest,
+                String::from("*3"),
+                false,
+                NodeKind::Eclair,
+            ),
+        );
+        hash_map.insert(
+            NodeKind::Bitcoind,
+            ImageInfo::new(
+                payload.images.bitcoind.latest.clone(),
+                String::from("*4"),
+                false,
+                NodeKind::Bitcoind,
+            ),
+        );
+        hash_map.insert(
+            NodeKind::BitcoindMiner,
+            ImageInfo::new(
+                payload.images.bitcoind.latest,
+                String::from("*5"),
+                false,
+                NodeKind::BitcoindMiner,
+            ),
+        );
+        Ok(hash_map)
+    } else {
+        Err(anyhow!(
+            "HTTP request failed with status: {}",
+            response.status()
+        ))
+    }
+}
+
+pub fn get_polar_images() -> Result<CloneableHashMap<NodeKind, Vec<ImageInfo>>, Error> {
+    let url = "https://raw.githubusercontent.com/jamaljsr/polar/master/docker/nodes.json";
+
+    let response = get(url).map_err(|err| anyhow!("error getting polar images: {}", err))?;
+    if response.status().is_success() {
+        let payload: Payload = response.json::<Payload>().expect("Failed to parse JSON");
+        let mut hash_map: CloneableHashMap<NodeKind, Vec<ImageInfo>> = CloneableHashMap::new();
+        // NOTE: safe to use * as name since the grammar of the parse wont allow for special characters for the image name, only for the image tag
+
+        let lnd_versions: Vec<ImageInfo> = payload
+            .images
+            .lnd
+            ._versions
+            .iter()
+            .enumerate()
+            .map(|(index, version)| {
+                ImageInfo::new(version.to_owned(), format!("*_lnd-{}", index), false, NodeKind::Lnd)
+            })
+            .collect();
+        hash_map.insert(NodeKind::Lnd, lnd_versions);
+
+        let c_lightning_versions: Vec<ImageInfo> = payload
+            .images
+            .c_lightning
+            ._versions
+            .iter()
+            .enumerate()
+            .map(|(index, version)| {
+                ImageInfo::new(version.to_owned(), format!("*_clightning-{}", index), false, NodeKind::Coreln)
+            })
+            .collect();
+        hash_map.insert(NodeKind::Coreln, c_lightning_versions);
+
+        let eclair_versions: Vec<ImageInfo> = payload
+            .images
+            .eclair
+            ._versions
+            .iter()
+            .enumerate()
+            .map(|(index, version)| {
+                ImageInfo::new(version.to_owned(), format!("*_eclair-{}", index), false, NodeKind::Eclair)
+            })
+            .collect();
+
+        hash_map.insert(NodeKind::Eclair, eclair_versions);
+        let bitcoind_versions: Vec<ImageInfo> = payload
+            .images
+            .bitcoind
+            ._versions
+            .iter()
+            .enumerate()
+            .map(|(index, version)| {
+                ImageInfo::new(version.to_owned(), format!("*_bitcoind-{}", index), false, NodeKind::Bitcoind)
+            })
+            .collect();
+
+        hash_map.insert(NodeKind::Bitcoind, bitcoind_versions.clone());
+        hash_map.insert(NodeKind::BitcoindMiner, bitcoind_versions);
+        Ok(hash_map)
+    } else {
+        Err(anyhow!(
+            "HTTP request failed with status: {}",
+            response.status()
+        ))
+    }
+}


### PR DESCRIPTION
adds the needed grammar and support for setting docker images based on release tags from polar, will default to use the latest images. Additionally their is experimental support for using custom images when following along with the polar docs on how to create them. This will be further expanded and support over time.