### PR TITLE
External lnd override

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 !Dockerfile.visualizer
 !data/
 doppler.db
+!external_nodes/

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@
 /data
 /.vscode
 doppler-cluster.yaml
-/scripts/container_aliases.sh
+/scripts/aliases.sh
 doppler.db
+external_nodes/info.conf
+external_nodes/*/*

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 The DSL should empower developers to compose a concise script that configures an entire cluster of nodes running a single docker network, even if they are of different implementation types, to suit precise testing requirements. This should provide a sensation similar to working with a set of Lego blocks, where all the necessary components are at your fingertips, ready to be assembled based on the idea at hand.
 
+Additionally, this DSL can be used against a cluster of remote LND nodes (more implementations will follow) to generate activity across them. This could be payments or channel related activity at the moment, but more work can be done to further expand this to include starting and stopping the remote nodes as well as funding them from a configured faucet. Still would not recommend running these doppler files on a mainnet cluster of nodes, but I wont stop you from being reckless :wink:
+
 #### How to use:
 - More information on how to use this tool can be found here: [USAGE.md](./docs/USAGE.md)
 
@@ -26,15 +28,17 @@ The DSL should empower developers to compose a concise script that configures an
 - [x] SEND_HOLD_LN -- only works for LND nodes
 - [x] SEND_COINS --  to send from a btc miner to any of the L2 node types (helpful in making sure there are enough funds for channels to open)
 - [x] FORCE_CLOSE_CHANNEL - forces an L2 node to close a give channel
-- [x] TAG - allows for hodl invoices payment hashes to be stored between doppler files being run, enable a shared state between files (these will be used in the future to enable closing a specific channel with another node instead of just picking one at random)
+- [x] TAG - allows for hodl invoices payment hashes to be stored between doppler files being run, enable a shared state between files (these will be used in the future to enable closing a specific channel with another node instead of just picking one at random that the two nodes share)
 - [x] STOP_BTC - stops a BTC container
 - [x] START_BTC - starts a BTC container
 - [x] STOP_LN - stops a LN container
 - [x] START_LN - starts a LN container
+- [x] WAIT BLOCKS - uses one of the hooked up LND nodes and waits to proceed in the script until a certain block height is reached
 
 ### Interesting Simulations
 - Chain of force closures due to an inflight htlc: [force_closures](./doppler_files/force_close/README.md)
 - Executing a successful hodl invoice in lnd nodes: [hodl_invoice](./doppler_files/hold_invoices/README.md)
+- Using external LND nodes and generating payment activity: [external_nodes](./doppler_files/external_nodes/README.md)
 - Running with multiple versions of lightning implementations: [different_versions](./doppler_files/different_images/different_images.doppler)
 
 ### Acknowledgments

--- a/bash_examples/customer_merchant_courier_hold_invoice/1_hold_invoice.sh
+++ b/bash_examples/customer_merchant_courier_hold_invoice/1_hold_invoice.sh
@@ -1,4 +1,4 @@
-source ./scripts/container_aliases.sh
+source ./scripts/aliases.sh
 
 customer_hash=$(customer addinvoice | jq -r '.r_hash')
 echo $customer_hash

--- a/bash_examples/customer_merchant_courier_hold_invoice/2_hold_invoice.sh
+++ b/bash_examples/customer_merchant_courier_hold_invoice/2_hold_invoice.sh
@@ -1,4 +1,4 @@
-source ./scripts/container_aliases.sh
+source ./scripts/aliases.sh
 
 customer_list=$(customer listpayments --include_incomplete | jq -r '.payments |sort_by(-(.creation_time_ns | tonumber))' )
 customer_payment_hash=$(echo $customer_list  | jq -r ' .[0].payment_hash')

--- a/bash_examples/customer_merchant_courier_hold_invoice/3_hold_invoice.sh
+++ b/bash_examples/customer_merchant_courier_hold_invoice/3_hold_invoice.sh
@@ -1,4 +1,4 @@
-source ./scripts/container_aliases.sh
+source ./scripts/aliases.sh
 
 customer_list=$(customer listpayments --include_incomplete | jq -r '.payments |sort_by(-(.creation_time_ns | tonumber))' )
 customer_payment_hash=$(echo $customer_list  | jq -r ' .[0].payment_hash')

--- a/bash_examples/failed_keysend.sh
+++ b/bash_examples/failed_keysend.sh
@@ -8,7 +8,7 @@
 # result: 
 # carol fails the payment with failure reason FAILURE_REASON_INCORRECT_PAYMENT_DETAILS 
 # and failure code 1 (INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS)
-source ./scripts/container_aliases.sh
+source ./scripts/aliases.sh
 
 alice_pk=$(alice getinfo | jq '.identity_pubkey' -r)
 carol_pk=$(carol getinfo | jq '.identity_pubkey' -r)

--- a/bash_examples/fee_bumping.sh
+++ b/bash_examples/fee_bumping.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source ./scripts/container_aliases.sh
+source ./scripts/aliases.sh
 
 alice pendingchannels
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -7,6 +7,9 @@ cargo run --bin doppler -- -f "doppler_files/only_setup_network.doppler" -d
 - add a new .doppler file to create the cluster how you want
 - examples of the possible valid grammar for the doppler files can be found in [doppler_files](../doppler_files/)
 
+### Example on how to hook up to remote LND nodes
+- [remote_nodes](../doppler_files/external_nodes/README.md)
+
 ### Start Blockly editor UI
 
 ```
@@ -79,7 +82,7 @@ cargo run --bin doppler -- -f "doppler_files/only_setup_network.doppler" -l "deb
 once the cluster as gotten past the `up` command, you'll see a new file which contains the aliases and can be run like below
 
 ```
-source ./scripts/container_aliases.sh
+source ./scripts/aliases.sh
 ```
 
 this allows you to call the containers like this from your current command prompt session:

--- a/doppler_files/external_nodes/README.md
+++ b/doppler_files/external_nodes/README.md
@@ -1,0 +1,17 @@
+### How to use these scripts for local doppler nodes or remote nodes
+- For local:
+1. Run [local_setup.doppler](local_setup.doppler) via `cargo run doppler -- -f "doppler_files/external_nodes/local_setup.doppler"`
+2. Open a new command console and run [setup_channels.doppler](setup_channels.doppler) via `cargo run doppler -- -f "doppler_files/external_nodes/setup_channels.doppler"`
+3. In that same console, run [exchange_activity.doppler](exchange_activity.doppler) via `cargo run doppler -- -f "doppler_files/external_nodes/exchange_activity.doppler"`
+4. Open another new command console and run [merchant_activity.doppler](merchant_activity.doppler) via `cargo run doppler -- -f "doppler_files/external_nodes/merchant_activity.doppler"`
+- Leave these three command consoles running and you will see generated payment activity on your local cluster, this is handle for testing an application which uses lightning
+
+- For Remote:
+1. Setup your nodes somewhere on a remote server, right now doppler will only be able to support LND nodes that are remotely hosted but eventually it should be able to support Eclair and CoreLn as well. 
+2. Once the LND nodes are provisioned and have some bitcoin on them, download the tls.cert, admin.macaroon, and make note of the domain each is running one. You will need three remote nodes for this simulation
+3. Follow how [external_nodes](../../external_nodes/info.example.conf) is setup, change the name of the file to `info.conf`. Place your tls and admin macaroons in the respective folders under each alias for the nodes. Once the files are place in the location that info.conf expects for each node, move on to the next step
+4. At this point you are running to actually run the doppler simulation against your nodes, if there aren't any channels setup with them yet run this script (at the root of the project):
+[setup_channels.doppler](setup_channels.doppler) via `cargo run doppler -- -f "doppler_files/external_nodes/setup_channels.doppler" --external_nodes="external_nodes/info.conf"` 
+5. In that same console, run [exchange_activity.doppler](exchange_activity.doppler) via `cargo run doppler -- -f "doppler_files/external_nodes/exchange_activity.doppler" --external_nodes="external_nodes/info.conf"`
+6.  Open another new command console and run [merchant_activity.doppler](merchant_activity.doppler) via `cargo run doppler -- -f "doppler_files/external_nodes/merchant_activity.doppler" --external_nodes="external_nodes/info.conf"`
+- Leave these two command consoles running and you will see generated payment activity on your remote cluster, this is handle for testing an application which use lightning and especially ones that need to validate against a large amount of historical lightning data.

--- a/doppler_files/external_nodes/exchange_activity.doppler
+++ b/doppler_files/external_nodes/exchange_activity.doppler
@@ -1,0 +1,9 @@
+SKIP_CONF
+
+LOOP EVERY 30m
+    exchange SEND_LN customer AMT 10
+END
+
+LOOP EVERY 20s
+    exchange SEND_LN merchant AMT 100
+END

--- a/doppler_files/external_nodes/local_setup.doppler
+++ b/doppler_files/external_nodes/local_setup.doppler
@@ -1,0 +1,16 @@
+BITCOIND_MINER bd1 30s
+
+LND exchange PAIR bd1
+LND customer PAIR bd1
+LND merchant PAIR bd1
+
+VISUALIZER view
+UP
+bd1 SEND_COINS merchant AMT 5000000
+bd1 SEND_COINS exchange AMT 5000000
+bd1 SEND_COINS customer AMT 5000000
+bd1 MINE_BLOCKS 50
+
+LOOP EVERY 30s
+    bd1 MINE_BLOCKS 1
+END

--- a/doppler_files/external_nodes/merchant_activity.doppler
+++ b/doppler_files/external_nodes/merchant_activity.doppler
@@ -1,0 +1,14 @@
+SKIP_CONF
+
+LOOP EVERY 20s
+    merchant WAIT BLOCKS 10
+    merchant SEND_LN exchange AMT 100
+END
+
+LOOP EVERY 30m
+    customer SEND_LN exchange AMT 10
+    customer SEND_HOLD_LN merchant AMT 350 TAG customer_payment
+    merchant WAIT BLOCKS 10
+    merchant SETTLE_HOLD_LN customer TAG customer_payment
+END
+

--- a/doppler_files/external_nodes/setup_channels.doppler
+++ b/doppler_files/external_nodes/setup_channels.doppler
@@ -1,0 +1,8 @@
+SKIP_CONF
+customer OPEN_CHANNEL merchant AMT 50000
+merchant OPEN_CHANNEL customer AMT 50000
+merchant OPEN_CHANNEL exchange AMT 50000
+exchange WAIT BLOCKS 3
+
+exchange OPEN_CHANNEL merchant AMT 50000
+exchange WAIT BLOCKS 6

--- a/external_nodes/info.example.conf
+++ b/external_nodes/info.example.conf
@@ -1,0 +1,17 @@
+[customer]
+ADMIN_MACAROON_PATH=<full/path/to/file>
+API_ENDPOINT=<api domain>
+TLS_CERT_PATH=<full/path/to/file>
+NETWORK=<signet|testnet> 
+
+[merchant]
+ADMIN_MACAROON_PATH=<full/path/to/file>
+API_ENDPOINT=<api domain>
+TLS_CERT_PATH=<full/path/to/file>
+NETWORK=<signet|testnet> 
+
+[exchange]
+ADMIN_MACAROON_PATH=<full/path/to/file>
+API_ENDPOINT=<api domain>
+TLS_CERT_PATH=<full/path/to/file>
+NETWORK=<signet|testnet> 

--- a/src/cln.rs
+++ b/src/cln.rs
@@ -137,17 +137,20 @@ impl L2Node for Cln {
         _rhash: String,
     ) -> Result<String, Error> {
         // Not implemented yet, needs some more research into their api
-        unimplemented!();
+        unimplemented!("only implemented for LND nodes at the moment");
     }
     fn settle_hold_invoice(&self, _options: &Options, _preimage: String) -> Result<(), Error> {
         // Not implemented yet, needs some more research into their api
-        unimplemented!();
+        unimplemented!("only implemented for LND nodes at the moment");
     }
     fn get_rhash(&self, option: &Options) -> Result<String, Error> {
         get_rhash(self, option)
     }
     fn get_preimage(&self, _option: &Options, _rhash: String) -> Result<String, Error> {
-        unimplemented!();
+        unimplemented!("only implemented for LND nodes at the moment");
+    }
+    fn wait_for_block(&self, _options: &Options, _num_of_blocks: i64) -> Result<(), Error> {
+        unimplemented!("only implemented for LND nodes at the moment");
     }
 }
 

--- a/src/eclair.rs
+++ b/src/eclair.rs
@@ -128,7 +128,7 @@ impl L2Node for Eclair {
         get_rhash(self, option)
     }
     fn get_preimage(&self, _option: &Options, _rhash: String) -> Result<String, Error> {
-        unimplemented!();
+        unimplemented!("only implemented for LND nodes at the moment");
     }
     fn create_hold_invoice(
         &self,
@@ -137,11 +137,14 @@ impl L2Node for Eclair {
         _rhash: String,
     ) -> Result<String, Error> {
         // Not implemented yet, needs some more research into their api
-        unimplemented!();
+        unimplemented!("only implemented for LND nodes at the moment");
     }
     fn settle_hold_invoice(&self, _options: &Options, _preimage: String) -> Result<(), Error> {
         // Not implemented yet, needs some more research into their api
-        unimplemented!();
+        unimplemented!("only implemented for LND nodes at the moment");
+    }
+    fn wait_for_block(&self, _options: &Options, _num_of_blocks: i64) -> Result<(), Error> {
+        unimplemented!("only implemented for LND nodes at the moment");
     }
 }
 

--- a/src/lnd_actions/lnd_rest.rs
+++ b/src/lnd_actions/lnd_rest.rs
@@ -460,7 +460,10 @@ impl LndRest {
             if error.is_string() && !error.as_str().unwrap().is_empty() {
                 error!(
                     options.global_logger(),
-                    "failed to make payment from {} to {}: {}", node_command.from, node_command.to, result_text
+                    "failed to make payment from {} to {}: {}",
+                    node_command.from,
+                    node_command.to,
+                    result_text
                 )
             }
         }
@@ -623,6 +626,29 @@ impl LndRest {
             error!(options.global_logger(), "failed to settle invoice",);
         }
         Ok(())
+    }
+    pub fn get_current_block(&self, options: &Options) -> Result<i64, Error> {
+        let url = self.build_url("/v2/chainkit/bestblock");
+        let result = self.send_request(
+            options,
+            "getbestblock".to_owned(),
+            Method::GET,
+            url,
+            None,
+            None,
+        )?;
+        if !result.status().is_success() {
+            error!(
+                options.global_logger(),
+                "failed to get getbestblock: {}",
+                result.text()?
+            );
+            return Ok(0);
+        }
+        let response_payload: Value = result.json()?;
+        let found_block_height: Option<i64> =
+            response_payload.get("block_height").and_then(Value::as_i64);
+        Ok(found_block_height.unwrap())
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,11 @@ pub struct Cli {
     #[arg(short, long)]
     rest: bool,
 
+    /// Path to override file for external LND nodes
+    /// Doppler scripts can only use these nodes matching aliases when set
+    #[arg(short, long)]
+    external_nodes: Option<String>,
+
     #[command(subcommand)]
     app_sub_commands: Option<AppSubCommands>,
 }
@@ -44,6 +49,7 @@ fn main() -> Result<(), Error> {
         cli.app_sub_commands,
         conn,
         cli.rest,
+        cli.external_nodes,
     );
     run_workflow_until_stop(&mut options, contents)?;
     info!(logger, "successfully cleaned up processes, shutting down");

--- a/src/node.rs
+++ b/src/node.rs
@@ -99,6 +99,7 @@ pub trait L2Node: Any {
     fn generate_memo(&self) -> String {
         generate_memo()
     }
+    fn wait_for_block(&self, options: &Options, num_of_blocks: i64) -> Result<(), Error>;
 }
 
 pub trait L1Node: Any {

--- a/src/parser/grammar.pest
+++ b/src/parser/grammar.pest
@@ -40,9 +40,10 @@ flag = { "--" }
 sub_command = { ( flag ~ ident | num )* }
 ln_timeout = { "TIMEOUT" ~ (num)* ~ time_digits }
 ln_amount = {"AMT" ~ num }
+ln_blocks = {"BLOCKS" ~ num }
 
-ln_node_action_type = { "OPEN_CHANNEL"  | "SEND_LN" | "SEND_HOLD_LN" | "SETTLE_HOLD_LN" | "SEND_ON_CHAIN" | "CLOSE_CHANNEL" | "FORCE_CLOSE_CHANNEL" | "STOP_LN" | "START_LN" }
-ln_node_action = { (image_name ~ ln_node_action_type ~ tag) | (image_name ~ ln_node_action_type ~ image_name ~ (ln_amount ~ (tag | ln_timeout ~ tag | sub_command)) | ln_amount ) | (image_name ~ ln_node_action_type ~ ( image_name ~ tag | image_name ~ sub_command | image_name)) | (image_name ~ ln_node_action_type) }
+ln_node_action_type = { "OPEN_CHANNEL"  | "SEND_LN" | "SEND_HOLD_LN" | "SETTLE_HOLD_LN" | "SEND_ON_CHAIN" | "CLOSE_CHANNEL" | "FORCE_CLOSE_CHANNEL" | "STOP_LN" | "START_LN" | "WAIT" }
+ln_node_action = { (image_name ~ ln_node_action_type ~ ln_blocks) | (image_name ~ ln_node_action_type ~ tag) | (image_name ~ ln_node_action_type ~ image_name ~ (ln_amount ~ (tag | ln_timeout ~ tag | sub_command)) | ln_amount ) | (image_name ~ ln_node_action_type ~ ( image_name ~ tag | image_name ~ sub_command | image_name)) | (image_name ~ ln_node_action_type) }
 
 btc_node_action_type = { "MINE_BLOCKS" | "STOP_BTC" | "START_BTC" | "SEND_COINS" }
 btc_node_action = { (image_name ~ btc_node_action_type ~ image_name ~ "AMT" ~ (num ~ sub_command | num )) | (image_name ~ btc_node_action_type ~ ( num ~ sub_command | num)) | (image_name ~ btc_node_action_type) }


### PR DESCRIPTION
This adds the MVP ability to run Doppler scripts against remotely hosted LND nodes. There is more work to be done here around adding additional support for other implementations and expanded the  Doppler commands supported, however, this is enough to be dangerous against a remote cluster of nodes and is a good cut to show how this DSL can be helpful build testing activity. More info can be found in the README on how to use this new feature.