### PR TITLE
adds custom installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ The DSL should empower developers to compose a concise script that configures an
 Additionally, this DSL can be used against a cluster of remote LND nodes (more implementations will follow) to generate activity across them. This could be payments or channel related activity at the moment, but more work can be done to further expand this to include starting and stopping the remote nodes as well as funding them from a configured faucet. Still would not recommend running these doppler files on a mainnet cluster of nodes, but we wont stop you from being reckless :wink:
 
 #### How to use:
+- Install via `export VERSION=<release tag to install> && curl --proto '=https' --tlsv1.2 -LsSf "https://github.com/tee8z/doppler/releases/download/${VERSION}/doppler-installer.sh" | sh -s -- "${VERSION}"`
 - More information on how to use this tool can be found here: [USAGE.md](./docs/USAGE.md)
 
 #### Supports:

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -7,23 +7,11 @@ members = ["npm:doppler_ui", "cargo:doppler"]
 cargo-dist-version = "0.23.0"
 # CI backends to support
 ci = "github"
-# The installers to generate for each app
-installers = ["shell"]
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu"]
-# Path that installers should place binaries in
-install-path = ["$DOPPLER_HOME/", "~/.doppler"]
 # Whether to install an updater program
 install-updater = false
 # Which actions to run on pull requests
 pr-run-mode = "plan"
-
-[workspace.metadata.dist.dependencies.apt]
-musl-tools = '*'
-libssl-dev = '*'
-
-
-[workspace.metadata.dist.github-actions.env]
-OPENSSL_DIR = "/usr/include/openssl"
-OPENSSL_STATIC = "1"
-PKG_CONFIG_ALLOW_CROSS = "1"
+# The installers to generate for each app
+installers = []

--- a/doppler-installer.sh
+++ b/doppler-installer.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+
+# Function to check if a command exists
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# Check if curl is installed
+if ! command_exists curl; then
+    echo "Error: curl is not installed. Please install curl and try again."
+    exit 1
+fi
+
+# Check if tar is installed
+if ! command_exists tar; then
+    echo "Error: tar is not installed. Please install tar and try again."
+    exit 1
+fi
+
+# Function to get OS and architecture
+get_os_arch() {
+    local os=$(uname -s | tr '[:upper:]' '[:lower:]')
+    local arch=$(uname -m)
+    
+    case "$os" in
+        linux*)
+            os="linux"
+            ;;
+        darwin*)
+            os="darwin"
+            ;;
+        *)
+            echo "Unsupported OS: $os"
+            exit 1
+            ;;
+    esac
+    
+    case "$arch" in
+        x86_64)
+            arch="x86_64"
+            ;;
+        aarch64|arm64)
+            arch="aarch64"
+            ;;
+        *)
+            echo "Unsupported architecture: $arch"
+            exit 1
+            ;;
+    esac
+    
+    echo "${os}-${arch}"
+}
+
+# Check if version is provided
+if [ $# -eq 0 ]; then
+    echo "Error: Please provide a version number."
+    echo "Usage: $0 <version>"
+    exit 1
+fi
+
+VERSION="$1"
+OS_ARCH=$(get_os_arch)
+
+# Base URL
+BASE_URL="https://github.com/tee8z/doppler/releases/download"
+
+get_cpu_architecture() {
+    if [[ "$(uname)" == "Darwin" ]]; then
+        echo $(uname -m)
+    else
+        echo $(uname -m)
+    fi
+}
+
+system=$(uname | tr '[:upper:]' '[:lower:]')
+arch=$(get_cpu_architecture)
+
+if [[ "$system" == "linux" ]]; then
+    filename="doppler-${arch}-unknown-linux-gnu.tar.xz"
+elif [[ "$system" == "darwin" ]]; then
+    if [[ "$arch" == "x86_64" ]]; then
+        filename="doppler-x86_64-apple-darwin.tar.xz"
+    elif [[ "$arch" == "arm64" ]] || [[ "$arch" == "aarch64" ]]; then
+        filename="doppler-aarch64-apple-darwin.tar.xz"
+    fi
+else
+    filename="doppler-${system}-${arch}.tar.xz"
+fi
+
+# Construct the full URL
+URL="${BASE_URL}/${VERSION}/${filename}"
+
+echo "Filename: $filename"
+
+# Destination folder
+DEST_FOLDER="$HOME/.doppler"
+
+# Create the destination folder if it doesn't exist
+mkdir -p "$DEST_FOLDER"
+
+echo "Downloading Doppler @ ${URL}"
+
+# Extract the base name from the filename (remove .tar.xz)
+BASE_NAME=$(basename "$filename" .tar.xz)
+
+# Set the destination folder
+DEST_FOLDER="$HOME/.doppler/${VERSION}"
+
+# Create the destination folder
+mkdir -p "$DEST_FOLDER"
+
+# Download and extract the file
+curl --proto '=https' --tlsv1.2 -LsSf "$URL" | tar -xJ --strip-components=1 -C "$DEST_FOLDER"
+
+# Check if the extraction was successful
+if [ $? -eq 0 ]; then
+    echo "Successfully downloaded and extracted Doppler ${VERSION} to $DEST_FOLDER"
+else
+    echo "Error: Failed to download or extract Doppler ${VERSION}"
+    exit 1
+fi

--- a/doppler/Cargo.toml
+++ b/doppler/Cargo.toml
@@ -11,6 +11,7 @@ include = [
     "../scripts/",
     "../docs/",
     "../bitcoind_images",
+    "../doppler-installer.sh"
 ]
 
 [dependencies]


### PR DESCRIPTION
The default install from cargo dist does not include any of the additional example and config files package in the archieve file. Additionally it completely misses the ui server's executable. The issue is corrected here by creating our own custom bash script to download from the git release page based on passed in version. This command is added to the README.md for easy of use.