### PR TITLE
Update doppler run commands to not switch directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ Execute installer with a [release tag](https://github.com/tee8z/doppler/releases
 ### Running after install:
 To run with UI (navigate to `0.0.0.0:3000` in your browser to view the UI)
 ```sh
-  cd $HOME/.doppler/<release tag> && node ./build
+  node $HOME/.doppler/<release tag>/build
 ```
 To run as cli
 ```sh
-  cd $HOME/.doppler && doppler -h
+  doppler -h $HOME/.doppler
 ```
 More information on how to use this tool can be found here: [USAGE.md](./docs/USAGE.md)
 


### PR DESCRIPTION
Currently, the `README` says to run doppler via:

UI:
```sh
  cd $HOME/.doppler/<release tag> && node ./build
```

CLI:
```sh
  cd $HOME/.doppler && doppler -h
```

I propose we change them respectively to:

```sh
 node $HOME/.doppler/<release tag>/build
```

```sh
doppler -h $HOME/.doppler
```

Reason being that when you're developing locally the current commands take you out of the directory you are currently working on doppler from which is unnecessary and annoying if you stop the server and have to navigate back on every run.