### PR TITLE
handle other connection types

### DIFF
--- a/doppler/Cargo.toml
+++ b/doppler/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "doppler"
-version = "0.4.1"
+version = "0.4.2"
 repository = "https://github.com/tee8z/doppler.git"
 
 [package.metadata.dist]

--- a/doppler_ui/package.json
+++ b/doppler_ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "doppler",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"repository": "github:tee8z/doppler",
 	"bin": {
 		"doppler_ui": "build/index.js"

--- a/doppler_ui/src/components/Visualizer.svelte
+++ b/doppler_ui/src/components/Visualizer.svelte
@@ -371,15 +371,36 @@
 				const filteredConfig = Object.entries(config).reduce((configAcc, [propKey, propValue]) => {
 					if (propValue != null && propValue !== '') {
 						if (isKeyOfConnectionConfig(propKey)) {
-							if (isDeployed && propKey === 'host' && typeof propValue === 'string') {
-								try {
-									const hostUrl = new URL(propValue);
-									const proxyPort = parseInt(hostUrl.port) + 1000;
-									// Replace the host with the proxy URL
-									configAcc[propKey] = `http://${window.location.hostname}:${proxyPort}`;
-								} catch (e) {
-									console.error('Error parsing host URL:', e);
-									configAcc[propKey] = propValue; // Fallback to original if parsing fails
+							if (isDeployed) {
+								switch (propKey) {
+									case 'host':
+										if (typeof propValue === 'string') {
+											try {
+												const hostUrl = new URL(propValue);
+												const proxyPort = parseInt(hostUrl.port) + 1000;
+												// Replace the host with the proxy URL
+												configAcc[propKey] = `http://${window.location.hostname}:${proxyPort}`;
+											} catch (e) {
+												console.error('Error parsing host URL:', e);
+												configAcc[propKey] = propValue; // Fallback to original if parsing fails
+											}
+										}
+										break;
+									case 'rpc_port':
+									case 'p2p_port':
+										if (typeof propValue === 'string') {
+											try {
+												// Handle "localhost:PORT" format
+												const [, port] = propValue.split(':');
+												configAcc[propKey] = `${window.location.hostname}:${port}`;
+											} catch (e) {
+												console.error(`Error parsing ${propKey}:`, e);
+												configAcc[propKey] = propValue; // Fallback to original if parsing fails
+											}
+										}
+										break;
+									default:
+										configAcc[propKey] = propValue;
 								}
 							} else {
 								configAcc[propKey] = propValue;


### PR DESCRIPTION
We need to show the host/port of the deployed box instead of the localhost connection for both rpc and p2p connection types as well. Additionally the cors-proxy server is improved to handle both http/https in a better way.